### PR TITLE
Dont use locked_by when looking for job

### DIFF
--- a/lib/generators/delayed_job/templates/migration.rb
+++ b/lib/generators/delayed_job/templates/migration.rb
@@ -13,7 +13,8 @@ class CreateDelayedJobs < ActiveRecord::Migration
       table.timestamps null: true
     end
 
-    add_index :delayed_jobs, [:priority, :run_at], name: "delayed_jobs_priority"
+    add_index :delayed_jobs, [:failed_at, :run_at, :locked_at, :queue], name: "ready_delayed_jobs_queue_last"
+    add_index :delayed_jobs, [:queue, :failed_at, :run_at, :locked_at], name: "ready_delayed_jobs_queue_first"
   end
 
   def self.down


### PR DESCRIPTION
Locked by check is used in cases when the worker dies and then it comes
back to life. Then we would want it to pick up the job he dropped when
dying. In our case we don't name our workers and the default is
host:pid. When the worker dies it is spawn again but its pid will be
different. So there is no (or very little) chance that we will have
worker with the same name. So there is no point for checking for it.
Moreover this check breaks usage of any index we could think of.
It's better for the job to time out and being picked up by another
worker.

Moreover this commit introduces better index for our use case of
Delayed::Job.

@karol-nowak @schiza @szymzet @iaintshine what do you guys think?
I put queue at the and of the index as sometimes we have workers without queue specified (which used to break our DJs and made it very slow with lot of jobs in DB for example notificatus and uploader).

From my very simple tests it seems that we could go from hundreds of ms to fraction of ms on reserve job query ;) 
