### PR TITLE
Bring back UPDATE first job reservation, with small changes

### DIFF
--- a/lib/generators/delayed_job/templates/migration.rb
+++ b/lib/generators/delayed_job/templates/migration.rb
@@ -15,6 +15,7 @@ class CreateDelayedJobs < ActiveRecord::Migration
 
     add_index :delayed_jobs, [:failed_at, :run_at, :locked_at, :queue], name: "ready_delayed_jobs_queue_last"
     add_index :delayed_jobs, [:queue, :failed_at, :run_at, :locked_at], name: "ready_delayed_jobs_queue_first"
+    add_index :delayed_jobs, [:locked_by, :locked_at], name: "delayed_jobs_after_reserve_select"
   end
 
   def self.down


### PR DESCRIPTION
This is basically bringing back a7e056c with some small change.

The reason for that is on Aurora, using the version that blindly select some amounts of jobs and tries to lock them one by one (as seen in  method) is pretty bad, when we fire it frequently. And it happens when we are procesing jobs that are fast. This solution brings back a single UPDATE, that locks a single job, and if it is successful, it fetched the job and processes it. This is better, because we're not spamming the DB with the same SELECTs over and over, but we can only queue up the UPDATE to wait for the row lock on the DB, which is a better solution (and doesn't affect the DB performance).

The small change here is also not using the worker.name for locking the rows (as in our environment, especially dockerized, we don't have guarantees of uniqueness; and we don't even really use it anymore, vide 9b7ac02). We're also adding the better index for SELECT after this UPDATE - obviously needs to be added to the service itself.